### PR TITLE
Set default encoding to ascii

### DIFF
--- a/src/trumpscript/main.py
+++ b/src/trumpscript/main.py
@@ -8,8 +8,9 @@ __author__ = 'github.com/samshadwell'
 
 
 def main():
-    # TrumpScript only runs in ascii mode. If you don't speak English
-    # you can't write TrumpScript.
+    # TrumpScript only runs in ascii mode. Strings written in languages
+    # other than English aren't understood or considered important by
+    # TrumpScript.
     sys.setdefaultencoding('ascii')
 
     if len(sys.argv) != 2:

--- a/src/trumpscript/main.py
+++ b/src/trumpscript/main.py
@@ -8,6 +8,10 @@ __author__ = 'github.com/samshadwell'
 
 
 def main():
+    # TrumpScript only runs in ascii mode. If you don't speak English
+    # you can't write TrumpScript.
+    sys.setdefaultencoding('ascii')
+
     if len(sys.argv) != 2:
         print("Invalid usage. Provide a TrumpScript file name to compile and run")
         print("Example: TRUMP trump_file.tr")


### PR DESCRIPTION
Python 3 defaults encoding to 'utf-8', however, writing programs in languages other than English conflicts with the ideals of TrumpScript.
