### PR TITLE
/bin/sh is not always bash

### DIFF
--- a/bin/TRUMP
+++ b/bin/TRUMP
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #SCRIPT=`readlink -f "$0"`
 #DIR=`dirname "$SCRIPT"`


### PR DESCRIPTION
mention /bin/bash explicitly

(got error mesage "Bad substitution" on my system where bin/sh points to dash instead of bash)
