### PR TITLE
Update TRUMP

### DIFF
--- a/bin/TRUMP
+++ b/bin/TRUMP
@@ -1,9 +1,4 @@
-#!/bin/bash
-
-#SCRIPT=`readlink -f "$0"`
-#DIR=`dirname "$SCRIPT"`
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$(dirname "$DIR")"
-
-export PYTHONPATH="$PYTHONPATH:$ROOT:$ROOT/src:"
-exec python3 "$ROOT/src/trumpscript/main.py" $1
+#!/bin/sh
+root=$(dirname -- "$0")/..
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$root/src"
+exec python3 -- "$root/src/trumpscript/main.py" "$@"


### PR DESCRIPTION
- `#!/bin/sh` is usable if you shy away from bashisms like `BASH_SOURCE`. That bashism in particular shouldn't be used because this script isn't meant to be sourced, so removing it is not a problem.
- Remove `cd`/`pwd` subshell because the absolute/normalised path isn't necessary, just the relative one
- Remove double `dirname`, because the `dirname` of `.` is `.`.
- `--` arguments, because it's always nice to know a program isn't going to treat your path as a switch
- Lowercase for non-environment variables
- Don't insert a blank element into `PYTHONPATH`
- Proper quoting in the `python3` invocation
- Pass all arguments to `main.py` rather than just the first
- Removed commented code!

---

Done mostly in retaliation to the `#!/bin/bash` shebang appearing on such a simple script!
