### PR TITLE
Make sure the OS is not Windows before checking for root

### DIFF
--- a/src/trumpscript/utils.py
+++ b/src/trumpscript/utils.py
@@ -48,7 +48,7 @@ class Utils:
         Make sure we're not executing as root, because America is strong
         :return:
         """
-        if os.geteuid() == 0:
+        if os.name != 'nt' and os.geteuid() == 0:
             raise Utils.SystemException('root')
 
     @staticmethod


### PR DESCRIPTION
When checking for Root on a non Windows OS we get:
AttributeError: 'module' object has no attribute 'geteuid'

Instead of correctly raising an OS exception.
